### PR TITLE
Fix CoffeeScript exported variables on files processed by Babel

### DIFF
--- a/packages/coffeescript/plugin/compile-coffeescript.js
+++ b/packages/coffeescript/plugin/compile-coffeescript.js
@@ -83,6 +83,11 @@ export class CoffeeCompiler extends CachingCompiler {
 
     let sourceMap = JSON.parse(output.v3SourceMap);
 
+    output.js = stripExportedVars(
+      output.js,
+      inputFile.getDeclaredExports().map(e => e.name)
+    );
+
     if (source.indexOf('`') !== -1) {
       // If source contains backticks, pass the coffee output through babel-compiler
       const doubleRoastedCoffee =
@@ -108,10 +113,7 @@ export class CoffeeCompiler extends CachingCompiler {
       }
     }
 
-    return addSharedHeader(stripExportedVars(
-      output.js,
-      inputFile.getDeclaredExports().map(e => e.name)
-    ), sourceMap);
+    return addSharedHeader(output.js, sourceMap);
   }
 
   addCompileResult(inputFile, sourceWithMap) {


### PR DESCRIPTION
The tests added on this branch were failing because the compile-coffeescript.js `stripExportedVars` function was processing JavaScript output by _Babel_, which processed the output of the CoffeeScript compiler; and Babel was converting CoffeeScript’s one-line initial `var` statement into a multiline `var` statement. The logic in `stripExportedVars` only looks at the first `var` line and doesn’t expect it to ever spill onto multiple lines, so it never found any variables past the first one.

There’s no reason to run `stripExportedVars` after the Babel compilation step, so I reordered the steps. Now it’s CoffeeScript compilation, then `stripExportedVars`, then Babel compilation. This passes the tests.
